### PR TITLE
 Visual studio build tools link update

### DIFF
--- a/Pico/Setup/PicoSetup.html
+++ b/Pico/Setup/PicoSetup.html
@@ -13144,7 +13144,7 @@ div#notebook {
 </blockquote>
 </li>
 <li>Install <a href="https://visualstudio.microsoft.com/downloads/">Visual Studio Code</a></li>
-<li>Install <a href="https://visualstudio.microsoft.com/downloads/">Build Tools for Visual Studio 2019</a><blockquote><ul>
+<li>Install <a href="https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022">Build Tools for Visual Studio 2022</a><blockquote><ul>
 <li>When prompted by the Built Tools for Visual Studio installer, you need to install the C++ build tools only.</li>
 <li>You must install the full "Windows 10 SDK" package as the SDK will need to build the <code>pioasm</code> and <code>elf2uf2</code> tools locally. Removing it from the list of installed items will mean that you will be unable to build Raspberry Pi Pico binaries.</li>
 <li>This takes a while.<figure>


### PR DESCRIPTION
Make the link for visual studio build tools more useful. Now takes directly to the downloadd (if browser js is enabled)