### PR TITLE
Fix broken project link on VGA webpage

### DIFF
--- a/DE1/VGA_Driver/Driver.html
+++ b/DE1/VGA_Driver/Driver.html
@@ -13335,7 +13335,7 @@ div#notebook {
                     <span class="p">.</span><span class="n">blank</span><span class="p">(</span><span class="n">VGA_BLANK_N</span><span class="p">)</span>
 <span class="p">);</span>
 </pre></div>
-<p><a href="./VGA_to_M10K.zip">This project</a> demonstrates the driver. The module which instantiates the driver writes a simple checkerboard pattern (pictured below) to M10K memory. The module uses the <code>next_x</code> and <code>next_y</code> outputs from the vga driver to set the read address for the memory and access pixel color information. Artifacts are from the camera and are not visible on the VGA. <br><br></p>
+<p><a href="./VGA_to_M10k.zip">This project</a> demonstrates the driver. The module which instantiates the driver writes a simple checkerboard pattern (pictured below) to M10K memory. The module uses the <code>next_x</code> and <code>next_y</code> outputs from the vga driver to set the read address for the memory and access pixel color information. Artifacts are from the camera and are not visible on the VGA. <br><br></p>
 <figure>
     <img align="center" width="500" height="500" src="checkerboard.png" alt='missing' />
     <center><figcaption>VGA driver rendering a checkerboard from M10K memory</figcaption></center>


### PR DESCRIPTION
Hey Hunter,
VGA webpage project link is broken on windows due to the capital letter in the VGA_to_M10K.zip not linking to the actual VGA_to_M10k.zip