### PR TITLE
Fixed a typo in Boids Algorithm

### DIFF
--- a/Pico/Animal_Movement/Boids-algorithm.html
+++ b/Pico/Animal_Movement/Boids-algorithm.html
@@ -13490,7 +13490,7 @@ if boid.y &lt; topmargin:
 <code>speed = sqrt(boid.vx*boid.vx + boid.vy*boid.vy)</code></li>
 <li>If <code>speed&gt;maxspeed</code>:<br>
 <code>boid.vx = (boid.vx/speed)*maxspeed</code><br>
-<code>boid.vy = (boid.vy/speed)*minspeed</code></li>
+<code>boid.vy = (boid.vy/speed)*maxspeed</code></li>
 <li>If <code>speed&lt;minspeed</code>:<br>
 <code>boid.vx = (boid.vx/speed)*minspeed</code><br>
 <code>boid.vy = (boid.vy/speed)*minspeed</code></li>

--- a/Pico/Animal_Movement/Boids-algorithm.ipynb
+++ b/Pico/Animal_Movement/Boids-algorithm.ipynb
@@ -386,7 +386,7 @@
     "`speed = sqrt(boid.vx*boid.vx + boid.vy*boid.vy)`\n",
     "2. If `speed>maxspeed`:<br>\n",
     "`boid.vx = (boid.vx/speed)*maxspeed`<br>\n",
-    "`boid.vy = (boid.vy/speed)*minspeed`\n",
+    "`boid.vy = (boid.vy/speed)*maxspeed`\n",
     "3. If `speed<minspeed`:<br>\n",
     "`boid.vx = (boid.vx/speed)*minspeed`<br>\n",
     "`boid.vy = (boid.vy/speed)*minspeed`"


### PR DESCRIPTION
Fixed the typo mentioned below in [Boids Algorithm](https://vanhunteradams.com/Pico/Animal_Movement/Boids-algorithm.html#Speed-limits)

Old code:
``` python
If speed>maxspeed:
boid.vx = (boid.vx/speed)*maxspeed
boid.vy = (boid.vy/speed)*minspeed
```

New code:
``` python
If speed>maxspeed:
boid.vx = (boid.vx/speed)*maxspeed
boid.vy = (boid.vy/speed)*maxspeed
```